### PR TITLE
Cross-compile on 2.11/2.12/2.13.0-RC1

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,6 +34,10 @@ object Settings {
         name := "Slick",
         description := "Scala Language-Integrated Connection Kit",
         libraryDependencies ++= Dependencies.mainDependencies,
+        unmanagedSourceDirectories in Compile += {
+          if (scalaVersion.value.startsWith("2.13.")) sourceDirectory.value / "main" / "scala-2.13"
+          else sourceDirectory.value / "main" / "scala-2.11_2.12"
+        },
         scalacOptions in (Compile, doc) ++= Seq(
           "-doc-source-url", s"https://github.com/slick/slick/blob/${Docs.versionTag(version.value)}/slick/src/main€{FILE_PATH}.scala",
           "-doc-root-content", "scaladoc-root.txt"
@@ -70,6 +74,10 @@ object Settings {
         scalacOptions in (Compile, doc) ++= Seq(
           "-doc-source-url", s"https://github.com/slick/slick/blob/${Docs.versionTag(version.value)}/slick-testkit/src/main€{FILE_PATH}.scala"
         ),
+        unmanagedSourceDirectories in Compile += {
+          if (scalaVersion.value.startsWith("2.13.")) sourceDirectory.value / "main" / "scala-2.13"
+          else sourceDirectory.value / "main" / "scala-2.11_2.12"
+        },
         testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a", "-Djava.awt.headless=true"),
         //scalacOptions in Compile += "-Yreify-copypaste",
         libraryDependencies ++=

--- a/slick-testkit/src/main/scala-2.11_2.12/com/typesafe/slick/testkit/util/VersionCompat.scala
+++ b/slick-testkit/src/main/scala-2.11_2.12/com/typesafe/slick/testkit/util/VersionCompat.scala
@@ -1,0 +1,7 @@
+package com.typesafe.slick.testkit.util
+
+private[testkit] object VersionCompat {
+
+  def standardInterpolator(process: String => String, args: scala.collection.Seq[Any], sc: StringContext): String =
+    sc.standardInterpolator(process, args)
+}

--- a/slick-testkit/src/main/scala-2.13/com/typesafe/slick/testkit/util/VersionCompat.scala
+++ b/slick-testkit/src/main/scala-2.13/com/typesafe/slick/testkit/util/VersionCompat.scala
@@ -1,0 +1,8 @@
+package com.typesafe.slick.testkit.util
+
+private[testkit] object VersionCompat {
+
+  // We may be able to get rid of this before 2.13.0 if https://github.com/scala/scala/pull/7983 is accepted
+  def standardInterpolator(process: String => String, args: scala.collection.Seq[Any], sc: StringContext): String =
+    StringContext.standardInterpolator(process, args, sc.parts)
+}

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/InsertTest.scala
@@ -183,7 +183,7 @@ class InsertTest extends AsyncTest[JdbcTestDB] {
     DBIO.seq()
   }
 
-  def testInsertOrUpdatePlainWithFuncDefinedPK: DBIOAction[Unit, _, _] = {
+  def testInsertOrUpdatePlainWithFuncDefinedPK: DBIOAction[Unit, NoStream, Effect.All] = {
     //FIXME remove this after fixed checkInsert issue
     if (tdb.profile.isInstanceOf[DerbyProfile]) return DBIO.successful(())
 

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/NestingTest.scala
@@ -28,7 +28,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val q1a = (for {
       (a, b) <- ts.map(t => (t.a, t.b))
       c <- ts.map(t => t.c)
-    } yield a ~ b ~ c ~ 5).sortBy(t => t._3 ~ t._1)
+    } yield (a, b, c, 5)).sortBy(t => t._3 ~ t._1)
 
     val q1c = (for {
       a ~ b <- ts.map(t => (t.a, t.b))
@@ -43,7 +43,7 @@ class NestingTest extends AsyncTest[RelationalTestDB] {
     val res2 = Set((1, "1", 8), (2, "2", 10))
 
     val q2a = for {
-      a ~ b ~ c <- ts.filter(_.a === 1).map(t => t.a ~ t.b ~ 4) unionAll ts.filter(_.a === 2).map(t => t.a ~ t.b ~ 5)
+      a ~ b ~ c <- ts.filter(_.a === 1).map(t => (t.a, t.b, 4)) unionAll ts.filter(_.a === 2).map(t => t.a ~ t.b ~ 5)
     } yield a ~ b ~ (c*2)
 
     val q2b = for {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/tests/RelationalScalarFunctionTest.scala
@@ -22,8 +22,8 @@ class RelationalScalarFunctionTest extends AsyncTest[RelationalTestDB] {
       checkLit(-17.5),
       checkLit(17.5f),
       checkLit(-17.5f),
-      checkLit(42l),
-      checkLit(-42l),
+      checkLit(42L),
+      checkLit(-42L),
       checkLit("foo"),
 
       check("42".asColumnOf[Int], 42),

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/Testkit.scala
@@ -146,7 +146,7 @@ sealed abstract class GenericTest[TDB >: Null <: TestDB](implicit TdbClass: Clas
 
   implicit class StringContextExtensionMethods(s: StringContext) {
     /** Generate a unique name suitable for a database entity */
-    def u(args: Any*) = s.standardInterpolator(identity, args) + "_" + unique.incrementAndGet()
+    def u(args: Any*) = VersionCompat.standardInterpolator(identity, args, s) + "_" + unique.incrementAndGet()
   }
 
   final def mark[T](id: String, f: => T): T = {

--- a/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
+++ b/slick-testkit/src/main/scala/com/typesafe/slick/testkit/util/TestkitConfig.scala
@@ -63,7 +63,7 @@ object TestkitConfig {
   def getStrings(config: Config, path: String): Option[Seq[String]] = {
     if(config.hasPath(path)) {
       config.getValue(path).unwrapped() match {
-        case l: java.util.List[_] => Some(l.asScala.map(_.toString))
+        case l: java.util.List[_] => Some(l.asScala.iterator.map(_.toString).toSeq)
         case o => Some(List(o.toString))
       }
     } else None

--- a/slick/src/main/scala-2.11_2.12/slick/util/VersionCompat.scala
+++ b/slick/src/main/scala-2.11_2.12/slick/util/VersionCompat.scala
@@ -1,0 +1,12 @@
+package slick.util
+
+import scala.collection.compat._
+import scala.collection.mutable.Builder
+
+private[slick] object VersionCompat {
+
+  def partiallyApply[From, A, C](bf: BuildFrom[From, A, C])(from: From): Factory[A, C] = new Factory[A, C] {
+    def apply(): Builder[A,C] = bf.newBuilder(from)
+    def apply(from: Nothing): Builder[A,C] = apply()
+  }
+}

--- a/slick/src/main/scala-2.13/slick/util/VersionCompat.scala
+++ b/slick/src/main/scala-2.13/slick/util/VersionCompat.scala
@@ -1,0 +1,14 @@
+package slick.util
+
+import scala.collection.{BuildFrom, Factory}
+import scala.collection.mutable.Builder
+
+private[slick] object VersionCompat {
+
+  // This should have been a method on `BuildFrom`. Maybe in Scala 2.14?
+  // See https://github.com/scala/scala-collection-compat/issues/196 for details
+  def partiallyApply[From, A, C](bf: BuildFrom[From, A, C])(from: From): Factory[A, C] = new Factory[A, C] {
+    def fromSpecific(it: IterableOnce[A]): C = bf.fromSpecific(from)(it)
+    def newBuilder: Builder[A, C] = bf.newBuilder(from)
+  }
+}

--- a/slick/src/main/scala/slick/ast/Node.scala
+++ b/slick/src/main/scala/slick/ast/Node.scala
@@ -667,7 +667,7 @@ final case class IfThenElse(clauses: ConstArray[Node]) extends SimplyTypedNode {
   def mapResultClauses(f: Node => Node, keepType: Boolean = false) =
     mapClauses(f, keepType, (i => i%2 == 1 || i == clauses.length-1))
   def ifThenClauses: Iterator[(Node, Node)] =
-    clauses.iterator.grouped(2).withPartial(false).map { case List(i, t) => (i, t) }
+    clauses.iterator.grouped(2).withPartial(false).map { case Seq(i, t) => (i, t) }
   def elseClause = clauses.last
 }
 

--- a/slick/src/main/scala/slick/ast/Type.scala
+++ b/slick/src/main/scala/slick/ast/Type.scala
@@ -2,7 +2,7 @@ package slick.ast
 
 import scala.language.{implicitConversions, higherKinds}
 import slick.SlickException
-import scala.collection.generic.CanBuild
+import scala.collection.compat._
 import scala.collection.mutable.{Builder, ArrayBuilder}
 import scala.reflect.{ClassTag, classTag => mkClassTag}
 import scala.annotation.implicitNotFound
@@ -174,10 +174,10 @@ abstract class TypedCollectionTypeConstructor[C[_]](val classTag: ClassTag[C[_]]
   }
 }
 
-class ErasedCollectionTypeConstructor[C[_]](canBuildFrom: CanBuild[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
+class ErasedCollectionTypeConstructor[C[_]](factory: Factory[Any, C[Any]], classTag: ClassTag[C[_]]) extends TypedCollectionTypeConstructor[C](classTag) {
   val isSequential = classOf[scala.collection.Seq[_]].isAssignableFrom(classTag.runtimeClass)
   val isUnique = classOf[scala.collection.Set[_]].isAssignableFrom(classTag.runtimeClass)
-  def createBuilder[E : ClassTag] = canBuildFrom().asInstanceOf[Builder[E, C[E]]]
+  def createBuilder[E : ClassTag] = factory.newBuilder.asInstanceOf[Builder[E, C[E]]]
 }
 
 object TypedCollectionTypeConstructor {
@@ -187,7 +187,7 @@ object TypedCollectionTypeConstructor {
   /** The standard TypedCollectionTypeConstructor for Set */
   def set = forColl[Set]
   /** Get a TypedCollectionTypeConstructor for an Iterable type */
-  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: CanBuild[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
+  implicit def forColl[C[X] <: Iterable[X]](implicit cbf: Factory[Any, C[Any]], tag: ClassTag[C[_]]): TypedCollectionTypeConstructor[C] =
     new ErasedCollectionTypeConstructor[C](cbf, tag)
   /** Get a TypedCollectionTypeConstructor for an Array type */
   implicit val forArray: TypedCollectionTypeConstructor[Array] = new TypedCollectionTypeConstructor[Array](arrayClassTag) {

--- a/slick/src/main/scala/slick/basic/BasicBackend.scala
+++ b/slick/src/main/scala/slick/basic/BasicBackend.scala
@@ -2,7 +2,6 @@ package slick.basic
 
 import slick.util.AsyncExecutor.{Priority, Continuation, Fresh, WithConnection}
 
-
 import java.io.Closeable
 import java.util.concurrent.atomic.{AtomicReferenceArray, AtomicLong}
 
@@ -11,6 +10,7 @@ import com.typesafe.config.Config
 import scala.concurrent.{Promise, ExecutionContext, Future}
 import scala.util.{Success, Failure}
 import scala.util.control.NonFatal
+import scala.collection.compat._
 
 import org.slf4j.LoggerFactory
 import org.reactivestreams._
@@ -186,7 +186,7 @@ trait BasicBackend { self =>
 
           def run(pos: Int): Future[Any] = {
             if (pos == len) Future.successful {
-              val b = sa.cbf()
+              val b = sa.cbf.newBuilder
               var i = 0
               while (i < len) {
                 b += results.get(i)

--- a/slick/src/main/scala/slick/compiler/ExpandTables.scala
+++ b/slick/src/main/scala/slick/compiler/ExpandTables.scala
@@ -40,7 +40,7 @@ class ExpandTables extends Phase {
       // structural type under a different identity when we are traversing the tree to modify it.
       val structs: Map[TypeSymbol, Type] = tree.collect[(TypeSymbol, (FieldSymbol, Type))] {
         case s @ Select(_ :@ (n: NominalType), sym: FieldSymbol) => baseIdentity(n.sourceNominalType.sym) -> (sym -> s.nodeType)
-      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap)))
+      }.toSeq.groupBy(_._1).mapValues(v => StructType(ConstArray.from(v.map(_._2).toMap))).toMap
       logger.debug("Found Selects for NominalTypes: "+structs.keySet.mkString(", "))
 
       val tables = new mutable.HashMap[TableIdentitySymbol, (TermSymbol, Node)]

--- a/slick/src/main/scala/slick/compiler/RewriteJoins.scala
+++ b/slick/src/main/scala/slick/compiler/RewriteJoins.scala
@@ -210,7 +210,7 @@ class RewriteJoins extends Phase {
       val m2 = m.mapValues(_.replace({
         case Ref(s) :@ tpe if s == j.leftGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(1)) :@ tpe
         case Ref(s) :@ tpe if s == j.rightGen => Select(Ref(outsideRef) :@ j2.nodeType.asCollectionType.elementType, ElementSymbol(2)) :@ tpe
-      }, keepType = true))
+      }, keepType = true)).toMap
       if(logger.isDebugEnabled) m2.foreach { case (p, n) =>
         logger.debug("Replacement for "+FwdPath.toString(p)+":", n)
       }
@@ -270,7 +270,7 @@ class RewriteJoins extends Phase {
     case b => b
   }
 
-  def splitConjunctions(n: Node): IndexedSeq[Node] = {
+  def splitConjunctions(n: Node): scala.collection.IndexedSeq[Node] = {
     val b = new ArrayBuffer[Node]
     def f(n: Node): Unit = n match {
       case Library.And(l, r) => f(l); f(r)
@@ -281,7 +281,7 @@ class RewriteJoins extends Phase {
     b
   }
 
-  def and(ns: IndexedSeq[Node]): Node =
+  def and(ns: scala.collection.IndexedSeq[Node]): Node =
     if(ns.isEmpty) LiteralNode(true) else ns.reduceLeft { (p1, p2) =>
       val t1 = p1.nodeType.structural
       Library.And.typed(if(t1.isInstanceOf[OptionType]) t1 else p2.nodeType.structural, p1, p2)

--- a/slick/src/main/scala/slick/lifted/AbstractTable.scala
+++ b/slick/src/main/scala/slick/lifted/AbstractTable.scala
@@ -100,7 +100,7 @@ abstract class AbstractTable[T](val tableTag: Tag, val schemaName: Option[String
   def index[T](name: String, on: T, unique: Boolean = false)(implicit shape: Shape[_ <: FlatShapeLevel, T, _, _]) = new Index(name, this, ForeignKey.linearizeFieldRefs(shape.toNode(on)), unique)
 
   def indexes: Iterable[Index] = (for {
-      m <- getClass().getMethods.view
+      m <- getClass().getMethods.iterator
       if m.getReturnType == classOf[Index] && m.getParameterTypes.length == 0
-    } yield m.invoke(this).asInstanceOf[Index]).sortBy(_.name)
+    } yield m.invoke(this).asInstanceOf[Index]).toIndexedSeq.sortBy(_.name)
 }


### PR DESCRIPTION
Using the current scala-collection-compat 1.0.0 which needs to be upgraded before a release.